### PR TITLE
removed "About" page

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -13,7 +13,6 @@
       {% endfor %}
     </ul>
   </li>
-  <li {% if page.about %}class="active"{% endif %}><a href="{{ site.baseurl }}/about/">About</a></li> 
   <li {% if page.help %}class="active"{% endif %}><a href="{{ site.baseurl }}/help/">Find help</a></li> 
 </ul>
 <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
I realize that between the landing page, "start here" and "find help", the About page is just going to be redundant. So i removed it
